### PR TITLE
Rename "stripelocal" to "stripe-mock"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,29 @@
-# stripelocal [![Build Status](https://travis-ci.org/brandur/stripelocal.svg?branch=master)](https://travis-ci.org/brandur/stripelocal)
+# stripe-mock [![Build Status](https://travis-ci.org/brandur/stripe-mock.svg?branch=master)](https://travis-ci.org/brandur/stripe-mock)
 
-A stub for the Stripe API powered by the OpenAPI specification that it
-generates as an artifact.
+stripe-mock is a mock HTTP server that responds like the real Stripe API. It can be used instead of Stripe's testmode to make test suites integrating with Stripe faster and less brittle.
 
 Get it from Homebrew or download it [from the releases page][releases]:
 
 ``` sh
-brew install brandur/stripelocal/stripelocal
+brew install brandur/stripe-mock/stripe-mock
 
-# start a stripelocal service at login
-brew services start stripelocal
+# start a stripe-mock service at login
+brew services start stripe-mock
 
 # upgrade if you already have it
-brew upgrade stripelocal
+brew upgrade stripe-mock
 ```
 
 Or if you have Go installed you can build it:
 
 ``` sh
-go get -u github.com/brandur/stripelocal
+go get -u github.com/brandur/stripe-mock
 ```
 
 Run it:
 
 ``` sh
-stripelocal
+stripe-mock
 ```
 
 Then from another terminal:
@@ -33,7 +32,7 @@ Then from another terminal:
 curl -i http://localhost:12111/v1/charges
 ```
 
-By default, stripelocal runs on port 12111, but is configurable with the
+By default, stripe-mock runs on port 12111, but is configurable with the
 `-port` option.
 
 ## Development
@@ -91,7 +90,7 @@ goreleaser
 
 [go-bindata]: https://github.com/jteeuwen/go-bindata
 [goreleaser]: https://github.com/goreleaser/goreleaser
-[releases]: https://github.com/brandur/stripelocal/releases
+[releases]: https://github.com/brandur/stripe-mock/releases
 
 <!--
 # vim: set tw=79:

--- a/generator.go
+++ b/generator.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 )
 
 var errExpansionNotSupported = fmt.Errorf("Expansion not supported")

--- a/generator_test.go
+++ b/generator_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 	assert "github.com/stretchr/testify/require"
 )
 

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,5 +1,5 @@
 build:
-  binary: stripelocal
+  binary: stripe-mock
   goos:
     - windows
     - darwin
@@ -10,9 +10,9 @@ build:
 brew:
   github:
     owner: brandur
-    name: homebrew-stripelocal
-  homepage: "https://github.com.com/brandur/stripelocal"
-  description: "stripelocal is a server that can be run locally and which responds like the real Stripe API."
+    name: homebrew-stripe-mock
+  homepage: "https://github.com.com/brandur/stripe-mock"
+  description: "stripe-mock is a mock HTTP server that responds like the real Stripe API. It can be used instead of Stripe's testmode to make test suites integrating with Stripe faster and less brittle."
 
   plist: |
     <?xml version="1.0" encoding="UTF-8"?>
@@ -28,7 +28,7 @@ brew:
         <string>#{plist_name}</string>
         <key>ProgramArguments</key>
         <array>
-          <string>#{opt_bin}/stripelocal</string>
+          <string>#{opt_bin}/stripe-mock</string>
           <string>-port</string>
           <string>12111</string>
         </array>
@@ -37,8 +37,8 @@ brew:
         <key>WorkingDirectory</key>
         <string>#{var}</string>
         <key>StandardErrorPath</key>
-        <string>#{var}/log/stripelocal.log</string>
+        <string>#{var}/log/stripe-mock.log</string>
         <key>StandardOutPath</key>
-        <string>#{var}/log/stripelocal.log</string>
+        <string>#{var}/log/stripe-mock.log</string>
       </dict>
     </plist>

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 )
 
 const defaultPort = 12111

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 )
 
 var chargeAllMethod *spec.Method

--- a/param/coercer/coercer.go
+++ b/param/coercer/coercer.go
@@ -3,7 +3,7 @@ package coercer
 import (
 	"strconv"
 
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 )
 
 // CoerceParams coerces the types of certain parameters according to typing

--- a/param/coercer/coercer_test.go
+++ b/param/coercer/coercer_test.go
@@ -3,7 +3,7 @@ package coercer
 import (
 	"testing"
 
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 	assert "github.com/stretchr/testify/require"
 )
 

--- a/server.go
+++ b/server.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/brandur/stripelocal/param/coercer"
-	"github.com/brandur/stripelocal/param/parser"
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/param/coercer"
+	"github.com/brandur/stripe-mock/param/parser"
+	"github.com/brandur/stripe-mock/spec"
 	"github.com/lestrrat/go-jsschema"
 	"github.com/lestrrat/go-jsval"
 	"github.com/lestrrat/go-jsval/builder"
@@ -305,7 +305,7 @@ func writeResponse(w http.ResponseWriter, start time.Time, status int, data inte
 		return
 	}
 
-	w.Header().Set("Stripelocal-Version", version)
+	w.Header().Set("Stripe-Mock-Version", version)
 
 	w.WriteHeader(status)
 	_, err = w.Write(encodedData)

--- a/server_test.go
+++ b/server_test.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/brandur/stripelocal/spec"
+	"github.com/brandur/stripe-mock/spec"
 	assert "github.com/stretchr/testify/require"
 )
 
@@ -21,7 +21,7 @@ func TestStubServer_SetsSpecialHeaders(t *testing.T) {
 
 	resp := w.Result()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
-	assert.Equal(t, version, resp.Header.Get("Stripelocal-Version"))
+	assert.Equal(t, version, resp.Header.Get("Stripe-Mock-Version"))
 }
 
 func TestStubServer_ParameterValidation(t *testing.T) {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -69,5 +69,5 @@
 			"revisionTime": "2015-06-20T23:27:11Z"
 		}
 	],
-	"rootPath": "github.com/brandur/stripelocal"
+	"rootPath": "github.com/brandur/stripe-mock"
 }


### PR DESCRIPTION
One final rename before we moved this over to the official GitHub
organization.